### PR TITLE
feat: implement teams page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,6 @@
     @apply animate-pulse bg-slate-200 dark:bg-zinc-700;
   }
   .skeleton-alt {
-    @apply animate-pulse bg-slate-50 dark:bg-zinc-700;
+    @apply animate-pulse bg-slate-50 dark:bg-zinc-600;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,4 +9,7 @@
   .skeleton {
     @apply animate-pulse bg-slate-200 dark:bg-zinc-700;
   }
+  .skeleton-alt {
+    @apply animate-pulse bg-slate-50 dark:bg-zinc-700;
+  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,6 @@
     @apply animate-pulse bg-slate-200 dark:bg-zinc-700;
   }
   .skeleton-alt {
-    @apply animate-pulse bg-slate-50 dark:bg-zinc-600;
+    @apply animate-pulse bg-slate-50 dark:bg-zinc-700;
   }
 }

--- a/src/app/shell/teams/loading.tsx
+++ b/src/app/shell/teams/loading.tsx
@@ -1,0 +1,5 @@
+import { TeamsSkeleton } from '@/components'
+
+export default function TeamsLoading() {
+  return <TeamsSkeleton />
+}

--- a/src/app/shell/teams/page.tsx
+++ b/src/app/shell/teams/page.tsx
@@ -1,3 +1,15 @@
+'use client'
+
+import { Button, PageHeading } from '@/components'
+
 export default function Teams() {
-  return <h1>Teams</h1>
+  return (
+    <div className="flex h-screen w-full flex-col items-start gap-6 bg-slate-200 p-16">
+      <PageHeading
+        title="Teams"
+        subtitle="Manage your teams, members, and team roles."
+      />
+      <Button onClick={() => {}}>Create new team</Button>
+    </div>
+  )
 }

--- a/src/app/shell/teams/page.tsx
+++ b/src/app/shell/teams/page.tsx
@@ -2,13 +2,18 @@
 
 import {
   Button,
+  CreateTeamModal,
   PageHeading,
   TeamsWrapper,
   TeamsSearchInput,
 } from '@/components'
 import { TeamsSearchContext } from '@/contexts'
+import { useState } from 'react'
 
 export default function Teams() {
+  const [isCreateTeamModalVisible, setIsCreateTeamModalVisible] =
+    useState(false)
+
   return (
     <div className="flex h-screen w-full flex-col items-start gap-6 overflow-auto bg-slate-200 p-16 dark:bg-zinc-800">
       <PageHeading
@@ -17,11 +22,17 @@ export default function Teams() {
       />
       <TeamsSearchContext>
         <div className="flex w-full gap-3">
-          <Button onClick={() => {}}>Create new team</Button>
+          <Button onClick={() => setIsCreateTeamModalVisible(true)}>
+            Create new team
+          </Button>
           <TeamsSearchInput />
         </div>
         <TeamsWrapper />
       </TeamsSearchContext>
+      <CreateTeamModal
+        isVisible={isCreateTeamModalVisible}
+        setIsVisible={setIsCreateTeamModalVisible}
+      />
     </div>
   )
 }

--- a/src/app/shell/teams/page.tsx
+++ b/src/app/shell/teams/page.tsx
@@ -1,6 +1,12 @@
 'use client'
 
-import { Button, PageHeading, TeamsWrapper } from '@/components'
+import {
+  Button,
+  PageHeading,
+  TeamsWrapper,
+  TeamsSearchInput,
+} from '@/components'
+import { TeamsSearchContext } from '@/contexts'
 
 export default function Teams() {
   return (
@@ -9,8 +15,13 @@ export default function Teams() {
         title="Teams"
         subtitle="Manage your teams, members, and team roles."
       />
-      <Button onClick={() => {}}>Create new team</Button>
-      <TeamsWrapper />
+      <TeamsSearchContext>
+        <div className="flex w-full gap-3">
+          <Button onClick={() => {}}>Create new team</Button>
+          <TeamsSearchInput />
+        </div>
+        <TeamsWrapper />
+      </TeamsSearchContext>
     </div>
   )
 }

--- a/src/app/shell/teams/page.tsx
+++ b/src/app/shell/teams/page.tsx
@@ -4,7 +4,7 @@ import { Button, PageHeading, TeamsWrapper } from '@/components'
 
 export default function Teams() {
   return (
-    <div className="flex h-screen w-full flex-col items-start gap-6 bg-slate-200 p-16">
+    <div className="flex h-screen w-full flex-col items-start gap-6 bg-slate-200 p-16 dark:bg-zinc-800">
       <PageHeading
         title="Teams"
         subtitle="Manage your teams, members, and team roles."

--- a/src/app/shell/teams/page.tsx
+++ b/src/app/shell/teams/page.tsx
@@ -1,46 +1,6 @@
 'use client'
 
-import { Button, PageHeading, Team } from '@/components'
-import { UserProfile } from '@/types'
-
-const userProfiles: UserProfile[] = [
-  {
-    avatar_id: null,
-    bio: 'Team Leader',
-    created_at: '2021-08-18T18:00:00.000Z',
-    first_name: 'John',
-    id: '1',
-    last_name: 'Doe',
-    user_id: '1234',
-  },
-  {
-    avatar_id: null,
-    bio: 'Team Leader',
-    created_at: '2021-08-18T18:00:00.000Z',
-    first_name: 'John',
-    id: '1',
-    last_name: 'Doe',
-    user_id: '1234',
-  },
-  {
-    avatar_id: null,
-    bio: 'Team Leader',
-    created_at: '2021-08-18T18:00:00.000Z',
-    first_name: 'John',
-    id: '1',
-    last_name: 'Doe',
-    user_id: '1234',
-  },
-  {
-    avatar_id: null,
-    bio: 'Team Leader',
-    created_at: '2021-08-18T18:00:00.000Z',
-    first_name: 'John',
-    id: '1',
-    last_name: 'Doe',
-    user_id: '1234',
-  },
-]
+import { Button, PageHeading, TeamsWrapper } from '@/components'
 
 export default function Teams() {
   return (
@@ -50,8 +10,7 @@ export default function Teams() {
         subtitle="Manage your teams, members, and team roles."
       />
       <Button onClick={() => {}}>Create new team</Button>
-      <Team members={userProfiles} name="California Team" />
-      <Team members={[]} name="Los Angeles Team" />
+      <TeamsWrapper />
     </div>
   )
 }

--- a/src/app/shell/teams/page.tsx
+++ b/src/app/shell/teams/page.tsx
@@ -1,6 +1,46 @@
 'use client'
 
-import { Button, PageHeading } from '@/components'
+import { Button, PageHeading, Team } from '@/components'
+import { UserProfile } from '@/types'
+
+const userProfiles: UserProfile[] = [
+  {
+    avatar_id: null,
+    bio: 'Team Leader',
+    created_at: '2021-08-18T18:00:00.000Z',
+    first_name: 'John',
+    id: '1',
+    last_name: 'Doe',
+    user_id: '1234',
+  },
+  {
+    avatar_id: null,
+    bio: 'Team Leader',
+    created_at: '2021-08-18T18:00:00.000Z',
+    first_name: 'John',
+    id: '1',
+    last_name: 'Doe',
+    user_id: '1234',
+  },
+  {
+    avatar_id: null,
+    bio: 'Team Leader',
+    created_at: '2021-08-18T18:00:00.000Z',
+    first_name: 'John',
+    id: '1',
+    last_name: 'Doe',
+    user_id: '1234',
+  },
+  {
+    avatar_id: null,
+    bio: 'Team Leader',
+    created_at: '2021-08-18T18:00:00.000Z',
+    first_name: 'John',
+    id: '1',
+    last_name: 'Doe',
+    user_id: '1234',
+  },
+]
 
 export default function Teams() {
   return (
@@ -10,6 +50,8 @@ export default function Teams() {
         subtitle="Manage your teams, members, and team roles."
       />
       <Button onClick={() => {}}>Create new team</Button>
+      <Team members={userProfiles} name="California Team" />
+      <Team members={[]} name="Los Angeles Team" />
     </div>
   )
 }

--- a/src/app/shell/teams/page.tsx
+++ b/src/app/shell/teams/page.tsx
@@ -4,7 +4,7 @@ import { Button, PageHeading, TeamsWrapper } from '@/components'
 
 export default function Teams() {
   return (
-    <div className="flex h-screen w-full flex-col items-start gap-6 bg-slate-200 p-16 dark:bg-zinc-800">
+    <div className="flex h-screen w-full flex-col items-start gap-6 overflow-auto bg-slate-200 p-16 dark:bg-zinc-800">
       <PageHeading
         title="Teams"
         subtitle="Manage your teams, members, and team roles."

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,19 +1,39 @@
 'use client'
 
-import { AvatarSkeleton } from '@/components'
+import { AvatarSkeleton, Icon } from '@/components'
 import { AvatarSize, UserProfile } from '@/types'
+import { faCrown } from '@fortawesome/free-solid-svg-icons'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
 import classNames from 'classnames'
 import Image from 'next/image'
-import { useEffect, useState } from 'react'
+import { PropsWithChildren, useEffect, useState } from 'react'
 
 interface Props {
   profile: UserProfile
   size?: AvatarSize
   customSrc?: string
+  isTeamLeader?: boolean
 }
 
-const Avatar = ({ profile, size = 'sm', customSrc }: Props) => {
+interface AvatarWrapperProps extends PropsWithChildren {
+  isTeamLeader?: boolean
+}
+
+const AvatarWrapper = ({ children, isTeamLeader }: AvatarWrapperProps) => {
+  return isTeamLeader ? (
+    <div className="relative">
+      {children}
+      <Icon
+        icon={faCrown}
+        className="absolute -left-2 -top-2 -rotate-45 text-lg text-yellow-500"
+      />
+    </div>
+  ) : (
+    children
+  )
+}
+
+const Avatar = ({ profile, size = 'sm', customSrc, isTeamLeader }: Props) => {
   const supabase = createClientComponentClient()
   const [src, setSrc] = useState('/avatar-placeholder.png')
   const [isFetching, setIsFetching] = useState(false)
@@ -45,16 +65,18 @@ const Avatar = ({ profile, size = 'sm', customSrc }: Props) => {
   const name = `${profile.first_name} ${profile.last_name}`
 
   return (
-    <Image
-      src={customSrc || src}
-      alt={`${name}'s Avatar`}
-      className={classNames('rounded-lg', {
-        'h-40 w-40': size === 'lg',
-        'h-10 w-10': size === 'sm',
-      })}
-      width={size === 'lg' ? 160 : 40}
-      height={size === 'lg' ? 160 : 40}
-    />
+    <AvatarWrapper isTeamLeader={isTeamLeader}>
+      <Image
+        src={customSrc || src}
+        alt={`${name}'s Avatar`}
+        className={classNames('rounded-lg', {
+          'h-40 w-40': size === 'lg',
+          'h-10 w-10': size === 'sm',
+        })}
+        width={size === 'lg' ? 160 : 40}
+        height={size === 'lg' ? 160 : 40}
+      />
+    </AvatarWrapper>
   )
 }
 

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -17,18 +17,17 @@ interface Props {
 }
 
 interface AvatarWrapperProps extends PropsWithChildren {
-  isTeamLeader?: boolean
+  isTeamLeader: boolean
+  withTooltip: boolean
 }
 
-const AvatarWrapper = ({ children, isTeamLeader }: AvatarWrapperProps) => {
-  return isTeamLeader ? (
-    <div className="relative">
-      {children}
-      <Icon
-        icon={faCrown}
-        className="absolute -left-2 -top-2 -rotate-45 text-lg text-yellow-500"
-      />
-    </div>
+const AvatarWrapper = ({
+  children,
+  isTeamLeader,
+  withTooltip,
+}: AvatarWrapperProps) => {
+  return isTeamLeader || withTooltip ? (
+    <div className="relative">{children}</div>
   ) : (
     children
   )
@@ -73,7 +72,7 @@ const Avatar = ({
   const name = `${profile.first_name} ${profile.last_name}`
 
   return (
-    <AvatarWrapper isTeamLeader={isTeamLeader}>
+    <AvatarWrapper isTeamLeader={isTeamLeader} withTooltip={withTooltip}>
       <Image
         src={customSrc || src}
         alt={`${name}'s Avatar`}
@@ -85,6 +84,12 @@ const Avatar = ({
         height={size === 'lg' ? 160 : 40}
         ref={avatarRef}
       />
+      {isTeamLeader && (
+        <Icon
+          icon={faCrown}
+          className="absolute -left-2 -top-2 -rotate-45 text-lg text-yellow-500"
+        />
+      )}
       {withTooltip && <Tooltip tooltipTargetRef={avatarRef} message={name} />}
     </AvatarWrapper>
   )

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,18 +1,19 @@
 'use client'
 
-import { AvatarSkeleton, Icon } from '@/components'
+import { AvatarSkeleton, Icon, Tooltip } from '@/components'
 import { AvatarSize, UserProfile } from '@/types'
 import { faCrown } from '@fortawesome/free-solid-svg-icons'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
 import classNames from 'classnames'
 import Image from 'next/image'
-import { PropsWithChildren, useEffect, useState } from 'react'
+import { PropsWithChildren, useEffect, useRef, useState } from 'react'
 
 interface Props {
   profile: UserProfile
   size?: AvatarSize
   customSrc?: string
   isTeamLeader?: boolean
+  withTooltip?: boolean
 }
 
 interface AvatarWrapperProps extends PropsWithChildren {
@@ -33,10 +34,17 @@ const AvatarWrapper = ({ children, isTeamLeader }: AvatarWrapperProps) => {
   )
 }
 
-const Avatar = ({ profile, size = 'sm', customSrc, isTeamLeader }: Props) => {
+const Avatar = ({
+  profile,
+  size = 'sm',
+  customSrc,
+  isTeamLeader = false,
+  withTooltip = false,
+}: Props) => {
   const supabase = createClientComponentClient()
   const [src, setSrc] = useState('/avatar-placeholder.png')
   const [isFetching, setIsFetching] = useState(false)
+  const avatarRef = useRef(null)
 
   useEffect(() => {
     if (customSrc || !profile.avatar_id?.length) {
@@ -75,7 +83,9 @@ const Avatar = ({ profile, size = 'sm', customSrc, isTeamLeader }: Props) => {
         })}
         width={size === 'lg' ? 160 : 40}
         height={size === 'lg' ? 160 : 40}
+        ref={avatarRef}
       />
+      {withTooltip && <Tooltip tooltipTargetRef={avatarRef} message={name} />}
     </AvatarWrapper>
   )
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -24,7 +24,7 @@ const Button = ({
       type={type}
       onClick={onClick}
       className={classNames(
-        'relative rounded-lg px-4 py-2 text-sm font-semibold transition-colors sm:px-5 sm:text-base',
+        'relative shrink-0 rounded-lg px-4 py-2 text-sm font-semibold transition-colors sm:px-5 sm:text-base',
         {
           'opacity-80': disabled,
           'bg-primary-500 text-primary-50 hover:bg-primary-600 dark:bg-primary-600 dark:hover:bg-primary-700':

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -35,7 +35,7 @@ const Button = ({
             color === 'yellow',
         },
       )}
-      disabled={disabled}
+      disabled={disabled || isLoading}
     >
       {children}
       {isLoading && (

--- a/src/components/ErrorModal.tsx
+++ b/src/components/ErrorModal.tsx
@@ -1,11 +1,8 @@
 import { Modal, CodeBlock, Icon, Link } from '@/components'
-import { Error } from '@/types'
+import { Error, ModalProps } from '@/types'
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons'
-import { Dispatch, SetStateAction } from 'react'
 
-interface Props {
-  isVisible: boolean
-  setIsVisible: Dispatch<SetStateAction<boolean>>
+interface Props extends ModalProps {
   error: Error
 }
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,11 +1,14 @@
 import classNames from 'classnames'
-import { RefObject } from 'react'
+import { ChangeEvent, RefObject } from 'react'
 
 interface Props {
   type?: 'text' | 'email' | 'password'
-  refObj: RefObject<HTMLInputElement>
-  id: string
+  refObj?: RefObject<HTMLInputElement>
+  value?: string
+  // eslint-disable-next-line no-unused-vars
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
   placeholder: string
+  id?: string
   isError?: boolean
   onFocus?: () => void
   autocomplete?:
@@ -14,32 +17,41 @@ interface Props {
     | 'family-name'
     | 'new-password'
     | 'current-password'
+  disabled?: boolean
 }
 
 const Input = ({
   type = 'text',
   refObj,
+  value,
+  onChange,
   id,
   placeholder,
   isError = false,
   onFocus,
   autocomplete,
+  disabled,
 }: Props) => {
   return (
     <input
       type={type}
       ref={refObj}
+      value={value}
+      onChange={onChange}
       id={id}
       className={classNames(
-        'w-full rounded-lg border-2 px-3 py-2 text-xs font-medium outline-none transition-colors sm:text-sm bg-slate-50',
+        'w-full rounded-lg border-2 bg-slate-50 px-3 py-2 text-xs font-medium outline-none transition-colors dark:bg-zinc-900 sm:text-sm',
         {
           'border-red-500 text-red-700': isError,
-          'border-slate-400 focus:border-slate-600': !isError,
+          'border-slate-400 focus:border-slate-600 dark:border-zinc-500 dark:focus:border-zinc-400':
+            !isError,
+          'opacity-50 cursor-not-allowed': disabled,
         },
       )}
       placeholder={placeholder}
       onFocus={onFocus}
       autoComplete={autocomplete || undefined}
+      disabled={disabled}
     />
   )
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,12 +1,11 @@
 'use client'
 
 import { Icon } from '@/components'
+import { ModalProps } from '@/types'
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
-import { Dispatch, PropsWithChildren, SetStateAction, useEffect } from 'react'
+import { PropsWithChildren, useEffect } from 'react'
 
-interface Props extends PropsWithChildren {
-  isVisible: boolean
-  setIsVisible: Dispatch<SetStateAction<boolean>>
+interface Props extends PropsWithChildren, ModalProps {
   disableBackdropClick?: boolean
 }
 
@@ -28,7 +27,7 @@ const Modal = ({
   return (
     isVisible && (
       <div
-        className="fixed left-0 top-0 z-40 grid h-screen w-screen place-items-center bg-slate-900 bg-opacity-50 dark:bg-zinc-100 dark:bg-opacity-20"
+        className="fixed left-0 top-0 z-40 grid h-screen w-screen place-items-center bg-slate-900 bg-opacity-50 dark:bg-zinc-400 dark:bg-opacity-20"
         onClick={disableBackdropClick ? undefined : () => setIsVisible(false)}
       >
         <div

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -12,12 +12,7 @@ const Navigation = () => {
   return (
     <nav className="grid gap-3">
       <NavItem title="Dashboard" icon={faHomeAlt} href={`/shell/dashboard`} />
-      <NavItem
-        title="Teams"
-        icon={faPeopleGroup}
-        href={`/shell/teams`}
-        disabled
-      />
+      <NavItem title="Teams" icon={faPeopleGroup} href={`/shell/teams`} />
       <NavItem
         title="Messages"
         icon={faEnvelope}

--- a/src/components/PageHeading.tsx
+++ b/src/components/PageHeading.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 const PageHeading = ({ title, subtitle }: Props) => {
   return (
-    <div className="flex flex-col">
+    <div className="flex w-full flex-col">
       <h1 className="mb-2 text-2xl font-semibold">{title}</h1>
       <h2 className="mb-4 text-slate-600 dark:text-zinc-400">{subtitle}</h2>
       <Spacer />

--- a/src/components/PageHeading.tsx
+++ b/src/components/PageHeading.tsx
@@ -3,14 +3,15 @@ import { Spacer } from '@/components'
 interface Props {
   title: string
   subtitle: string
+  noSpacer?: boolean
 }
 
-const PageHeading = ({ title, subtitle }: Props) => {
+const PageHeading = ({ title, subtitle, noSpacer = false }: Props) => {
   return (
     <div className="flex w-full flex-col">
       <h1 className="mb-2 text-2xl font-semibold">{title}</h1>
       <h2 className="mb-4 text-slate-600 dark:text-zinc-400">{subtitle}</h2>
-      <Spacer />
+      {!noSpacer && <Spacer />}
     </div>
   )
 }

--- a/src/components/Skeletons/AvatarSkeleton.tsx
+++ b/src/components/Skeletons/AvatarSkeleton.tsx
@@ -10,7 +10,7 @@ interface Props {
 const AvatarSkeleton = ({ size = 'sm', color = 'slate' }: Props) => {
   return (
     <div
-      className={classNames('rounded-lg', {
+      className={classNames('rounded-lg overflow-hidden', {
         'h-40 w-40': size === 'lg',
         'h-10 w-10': size === 'sm',
       })}

--- a/src/components/Skeletons/ImageSkeleton.tsx
+++ b/src/components/Skeletons/ImageSkeleton.tsx
@@ -7,13 +7,10 @@ interface Props {
 const ImageSkeleton = ({ color = 'slate' }: Props) => {
   return (
     <div
-      className={classNames(
-        'flex h-full w-full items-center justify-center rounded',
-        {
-          skeleton: color === 'slate',
-          'animate-pulse bg-primary-700': color === 'primary',
-        },
-      )}
+      className={classNames('flex h-full w-full items-center justify-center', {
+        skeleton: color === 'slate',
+        'animate-pulse bg-primary-700': color === 'primary',
+      })}
     >
       <svg
         className={classNames('aspect-square h-[20%] min-h-[1.5rem] w-auto', {

--- a/src/components/Skeletons/PageHeadingSkeleton.tsx
+++ b/src/components/Skeletons/PageHeadingSkeleton.tsx
@@ -1,10 +1,25 @@
 import { Spacer } from '@/components'
+import classNames from 'classnames'
 
-const PageHeadingSkeleton = () => {
+interface Props {
+  alt?: boolean
+}
+
+const PageHeadingSkeleton = ({ alt = false }: Props) => {
   return (
-    <div className="flex flex-col">
-      <div className="skeleton mb-2 h-8 w-1/12 rounded-full" />
-      <div className="skeleton mb-4 h-6 w-2/5 rounded-full" />
+    <div className="flex w-full flex-col">
+      <div
+        className={classNames('mb-2 h-8 w-1/5 rounded-full', {
+          skeleton: !alt,
+          'skeleton-alt': alt,
+        })}
+      />
+      <div
+        className={classNames('mb-4 h-6 w-3/5 rounded-full', {
+          skeleton: !alt,
+          'skeleton-alt': alt,
+        })}
+      />
       <Spacer />
     </div>
   )

--- a/src/components/Skeletons/TeamSkeleton.tsx
+++ b/src/components/Skeletons/TeamSkeleton.tsx
@@ -6,7 +6,7 @@ const TeamSkeleton = () => {
   return (
     <article className="grid w-full justify-items-start gap-3">
       <div className="skeleton-alt h-7 w-32 rounded-full" />
-      <div className="grid w-full gap-3 rounded-xl bg-slate-50 p-4 shadow-main">
+      <div className="grid w-full gap-3 rounded-xl bg-slate-50 dark:bg-zinc-900 p-4 shadow-main">
         <div className="flex gap-3">
           {Array.from({ length: 5 }).map((_, index) => (
             <AvatarSkeleton key={index} size="sm" />

--- a/src/components/Skeletons/TeamSkeleton.tsx
+++ b/src/components/Skeletons/TeamSkeleton.tsx
@@ -1,0 +1,25 @@
+import { AvatarSkeleton } from "@/components"
+
+AvatarSkeleton
+
+const TeamSkeleton = () => {
+  return (
+    <article className="grid w-full justify-items-start gap-3">
+      <div className="skeleton-alt h-7 w-32 rounded-full" />
+      <div className="grid w-full gap-3 rounded-xl bg-slate-50 p-4 shadow-main">
+        <div className="flex gap-3">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <AvatarSkeleton key={index} size="sm" />
+          ))}
+        </div>
+        <footer className="flex gap-6">
+          <div className="skeleton h-5 w-24 rounded-full" />
+          <div className="skeleton h-5 w-36 rounded-full" />
+          <div className="skeleton h-5 w-32 rounded-full" />
+        </footer>
+      </div>
+    </article>
+  )
+}
+
+export default TeamSkeleton

--- a/src/components/Skeletons/TeamsSkeleton.tsx
+++ b/src/components/Skeletons/TeamsSkeleton.tsx
@@ -1,0 +1,16 @@
+import { PageHeadingSkeleton, TeamsWrapperSkeleton } from '@/components'
+
+const TeamsSkeleton = () => {
+  return (
+    <div className="flex h-screen w-full flex-col items-start gap-6 overflow-auto bg-slate-200 p-16 dark:bg-zinc-800">
+      <PageHeadingSkeleton alt />
+      <div className="flex w-full gap-3">
+        <div className="skeleton-alt h-10 w-44 rounded-lg" />
+        <div className="skeleton-alt h-10 w-full rounded-lg" />
+      </div>
+      <TeamsWrapperSkeleton />
+    </div>
+  )
+}
+
+export default TeamsSkeleton

--- a/src/components/Skeletons/TeamsWrapperSkeleton.tsx
+++ b/src/components/Skeletons/TeamsWrapperSkeleton.tsx
@@ -1,0 +1,9 @@
+import { TeamSkeleton } from '@/components'
+
+const TeamsWrapperSkeleton = () => {
+  return Array.from({ length: 5 }).map((_, index) => (
+    <TeamSkeleton key={index} />
+  ))
+}
+
+export default TeamsWrapperSkeleton

--- a/src/components/Teams/CreateTeamModal.tsx
+++ b/src/components/Teams/CreateTeamModal.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import {
+  Button,
+  FormField,
+  Input,
+  InputError,
+  Label,
+  Modal,
+  Title,
+} from '@/components'
+import { useAuth } from '@/contexts'
+import { Database, ModalProps } from '@/types'
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { useRouter } from 'next/navigation'
+import { FormEvent, useRef, useState } from 'react'
+
+const CreateTeamModal = ({ isVisible, setIsVisible }: ModalProps) => {
+  const supabase = createClientComponentClient<Database>()
+  const { userProfile } = useAuth()
+  const teamNameInputRef = useRef<HTMLInputElement>(null)
+  const [error, setError] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const router = useRouter()
+
+  const handleCreateTeam = async (e: FormEvent<SubmitEvent>) => {
+    e.preventDefault()
+
+    if (!teamNameInputRef.current || !userProfile) return
+
+    const teamName = teamNameInputRef.current.value
+
+    if (teamName.trim().length === 0) {
+      setError('You have to specify team name')
+      return
+    }
+
+    setIsLoading(true)
+
+    const { error: insertError } = await supabase
+      .from('teams')
+      .insert({ name: teamName, organisation_id: userProfile.organisation_id })
+
+    setIsLoading(false)
+
+    if (insertError) {
+      if (insertError.code === '23505') {
+        setError('Team with specified name already exists')
+      } else {
+        setError(insertError.message)
+      }
+      return
+    }
+
+    router.push(`/shell/teams/${teamName}`)
+  }
+
+  return (
+    <Modal isVisible={isVisible} setIsVisible={setIsVisible}>
+      <form className="flex w-80 flex-col gap-6">
+        <Title>New Team</Title>
+        <FormField>
+          <Label htmlFor="newTeamName">Name</Label>
+          <Input
+            refObj={teamNameInputRef}
+            id="newTeamName"
+            placeholder="Team name..."
+            isError={!!error.length}
+            onFocus={() => setError('')}
+          />
+          <InputError message={error} />
+        </FormField>
+        <div className="flex justify-between">
+          <Button
+            disabled={isLoading}
+            onClick={() => setIsVisible(false)}
+            color="red"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            isLoading={isLoading}
+            onClick={handleCreateTeam}
+          >
+            Create
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  )
+}
+
+export default CreateTeamModal

--- a/src/components/Teams/Team.tsx
+++ b/src/components/Teams/Team.tsx
@@ -37,14 +37,14 @@ const Team = ({ data: { name, members } }: Props) => {
       >
         <Title>{name}</Title>
         <Icon
-          className="text-lg text-slate-600 dark:text-zinc-400 group-hover:animate-wiggle"
+          className="text-lg text-slate-600 group-hover:animate-wiggle dark:text-zinc-400"
           icon={faArrowRight}
         />
       </Link>
       <div className="grid w-full gap-3 rounded-xl bg-slate-50 p-4 shadow-main dark:bg-zinc-900">
         {members.length ? (
           <>
-            <div className="flex gap-3">
+            <div className="flex flex-wrap gap-3">
               {sortMembers(members).map((member) => (
                 <Avatar
                   key={member.id}

--- a/src/components/Teams/Team.tsx
+++ b/src/components/Teams/Team.tsx
@@ -9,8 +9,8 @@ interface Props {
 
 const sortMembers = (members: TeamMember[]) => {
   const sortedMembers = members.sort((memberA, memberB) => {
-    const memberAIsTeamLeader = (memberA.type = 'team_leader')
-    const memberBIsTeamLeader = (memberB.type = 'team_leader')
+    const memberAIsTeamLeader = memberA.type === 'team_leader'
+    const memberBIsTeamLeader = memberB.type === 'team_leader'
 
     if (memberAIsTeamLeader && !memberBIsTeamLeader) {
       return -1

--- a/src/components/Teams/Team.tsx
+++ b/src/components/Teams/Team.tsx
@@ -50,6 +50,7 @@ const Team = ({ data: { name, members } }: Props) => {
                   key={member.id}
                   size="sm"
                   profile={member}
+                  isTeamLeader={member.type === 'team_leader'}
                 />
               ))}
             </div>

--- a/src/components/Teams/Team.tsx
+++ b/src/components/Teams/Team.tsx
@@ -10,8 +10,8 @@ interface Props {
 
 const Team = ({ data: { name, members } }: Props) => {
   // TODO: Replace with real data
-  const ongoingProjects = 3
-  const assignedTasks = 12
+  const ongoingProjects = '-'
+  const assignedTasks = '-'
 
   return (
     <article className="grid w-full justify-items-start gap-3">

--- a/src/components/Teams/Team.tsx
+++ b/src/components/Teams/Team.tsx
@@ -1,14 +1,30 @@
 import { Avatar, TeamFooter, Icon, Title } from '@/components'
-import { UserProfile } from '@/types'
+import { TeamData, TeamMember } from '@/types'
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
 import Link from 'next/link'
 
 interface Props {
-  name: string
-  members: UserProfile[]
+  data: TeamData
 }
 
-const Team = ({ name, members }: Props) => {
+const sortMembers = (members: TeamMember[]) => {
+  const sortedMembers = members.sort((memberA, memberB) => {
+    const memberAIsTeamLeader = (memberA.type = 'team_leader')
+    const memberBIsTeamLeader = (memberB.type = 'team_leader')
+
+    if (memberAIsTeamLeader && !memberBIsTeamLeader) {
+      return -1
+    } else if (memberBIsTeamLeader && !memberAIsTeamLeader) {
+      return 1
+    } else {
+      return 0
+    }
+  })
+
+  return sortedMembers
+}
+
+const Team = ({ data: { name, members } }: Props) => {
   // TODO: Replace with real data
   const ongoingProjects = 3
   const assignedTasks = 12
@@ -25,12 +41,16 @@ const Team = ({ name, members }: Props) => {
           icon={faArrowRight}
         />
       </Link>
-      <div className="shadow-main grid w-full gap-3 rounded-xl bg-slate-50 p-4">
+      <div className="grid w-full gap-3 rounded-xl bg-slate-50 p-4 shadow-main">
         {members.length ? (
           <>
             <div className="flex gap-3">
-              {members.map((member) => (
-                <Avatar key={member.id} size="sm" profile={member} />
+              {sortMembers(members).map((member) => (
+                <Avatar
+                  key={member.id}
+                  size="sm"
+                  profile={member}
+                />
               ))}
             </div>
             <TeamFooter

--- a/src/components/Teams/Team.tsx
+++ b/src/components/Teams/Team.tsx
@@ -51,6 +51,7 @@ const Team = ({ data: { name, members } }: Props) => {
                   size="sm"
                   profile={member}
                   isTeamLeader={member.type === 'team_leader'}
+                  withTooltip
                 />
               ))}
             </div>

--- a/src/components/Teams/Team.tsx
+++ b/src/components/Teams/Team.tsx
@@ -1,27 +1,11 @@
 import { Avatar, TeamFooter, Icon, Title } from '@/components'
-import { TeamData, TeamMember } from '@/types'
+import { TeamData } from '@/types'
+import { sortTeamMembers } from '@/utils'
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
 import Link from 'next/link'
 
 interface Props {
   data: TeamData
-}
-
-const sortMembers = (members: TeamMember[]) => {
-  const sortedMembers = members.sort((memberA, memberB) => {
-    const memberAIsTeamLeader = memberA.type === 'team_leader'
-    const memberBIsTeamLeader = memberB.type === 'team_leader'
-
-    if (memberAIsTeamLeader && !memberBIsTeamLeader) {
-      return -1
-    } else if (memberBIsTeamLeader && !memberAIsTeamLeader) {
-      return 1
-    } else {
-      return 0
-    }
-  })
-
-  return sortedMembers
 }
 
 const Team = ({ data: { name, members } }: Props) => {
@@ -45,7 +29,7 @@ const Team = ({ data: { name, members } }: Props) => {
         {members.length ? (
           <>
             <div className="flex flex-wrap gap-3">
-              {sortMembers(members).map((member) => (
+              {sortTeamMembers(members).map((member) => (
                 <Avatar
                   key={member.id}
                   size="sm"

--- a/src/components/Teams/Team.tsx
+++ b/src/components/Teams/Team.tsx
@@ -1,0 +1,52 @@
+import { Avatar, TeamFooter, Icon, Title } from '@/components'
+import { UserProfile } from '@/types'
+import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
+import Link from 'next/link'
+
+interface Props {
+  name: string
+  members: UserProfile[]
+}
+
+const Team = ({ name, members }: Props) => {
+  // TODO: Replace with real data
+  const ongoingProjects = 3
+  const assignedTasks = 12
+
+  return (
+    <article className="grid w-full justify-items-start gap-3">
+      <Link
+        href={`/shell/teams/${name}`}
+        className="group flex items-center gap-3"
+      >
+        <Title>{name}</Title>
+        <Icon
+          className="text-lg text-slate-600 group-hover:animate-wiggle"
+          icon={faArrowRight}
+        />
+      </Link>
+      <div className="shadow-main grid w-full gap-3 rounded-xl bg-slate-50 p-4">
+        {members.length ? (
+          <>
+            <div className="flex gap-3">
+              {members.map((member) => (
+                <Avatar key={member.id} size="sm" profile={member} />
+              ))}
+            </div>
+            <TeamFooter
+              items={[
+                `Members: ${members.length}`,
+                `Ongoing Projects: ${ongoingProjects}`,
+                `Tasks Assigned: ${assignedTasks}`,
+              ]}
+            />
+          </>
+        ) : (
+          <p className="text-sm font-medium">This team is empty.</p>
+        )}
+      </div>
+    </article>
+  )
+}
+
+export default Team

--- a/src/components/Teams/Team.tsx
+++ b/src/components/Teams/Team.tsx
@@ -37,11 +37,11 @@ const Team = ({ data: { name, members } }: Props) => {
       >
         <Title>{name}</Title>
         <Icon
-          className="text-lg text-slate-600 group-hover:animate-wiggle"
+          className="text-lg text-slate-600 dark:text-zinc-400 group-hover:animate-wiggle"
           icon={faArrowRight}
         />
       </Link>
-      <div className="grid w-full gap-3 rounded-xl bg-slate-50 p-4 shadow-main">
+      <div className="grid w-full gap-3 rounded-xl bg-slate-50 p-4 shadow-main dark:bg-zinc-900">
         {members.length ? (
           <>
             <div className="flex gap-3">

--- a/src/components/Teams/TeamFooter.tsx
+++ b/src/components/Teams/TeamFooter.tsx
@@ -6,7 +6,10 @@ const TeamFooter = ({ items }: Props) => {
   return (
     <footer className="flex gap-6">
       {items.map((item, index) => (
-        <p key={index} className="text-sm font-medium text-slate-600">
+        <p
+          key={index}
+          className="text-sm font-medium text-slate-600 dark:text-zinc-400"
+        >
           {item}
         </p>
       ))}

--- a/src/components/Teams/TeamFooter.tsx
+++ b/src/components/Teams/TeamFooter.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  items: string[]
+}
+
+const TeamFooter = ({ items }: Props) => {
+  return (
+    <footer className="flex gap-6">
+      {items.map((item, index) => (
+        <p key={index} className="text-sm font-medium text-slate-600">
+          {item}
+        </p>
+      ))}
+    </footer>
+  )
+}
+
+export default TeamFooter

--- a/src/components/Teams/TeamsSearchInput.tsx
+++ b/src/components/Teams/TeamsSearchInput.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { ChangeEvent, useState } from 'react'
+import { Input } from '@/components'
+import { useTeamsSearchContext } from '@/contexts'
+
+const TeamsSearchInput = () => {
+  const [inputValue, setInputValue] = useState('')
+  const { teams, setQuery } = useTeamsSearchContext()
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value
+
+    setQuery(newValue)
+    setInputValue(newValue)
+  }
+
+  return (
+    <Input
+      value={inputValue}
+      onChange={handleInputChange}
+      disabled={!teams.length}
+      placeholder="Filter by team or member name..."
+    />
+  )
+}
+
+export default TeamsSearchInput

--- a/src/components/Teams/TeamsWrapper.tsx
+++ b/src/components/Teams/TeamsWrapper.tsx
@@ -1,16 +1,20 @@
 'use client'
 
-import { Team } from '@/components'
+import { Team, TeamSkeleton } from '@/components'
+import { useAuth } from '@/contexts'
 import { Database, TeamData } from '@/types'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
 import { useEffect, useState } from 'react'
 
 const TeamsWrapper = () => {
+  const { userProfile } = useAuth()
   const supabase = createClientComponentClient<Database>()
   const [teams, setTeams] = useState<TeamData[]>([])
+  const [isLoading, setIsLoading] = useState(false)
 
   useEffect(() => {
     const getTeams = async () => {
+      setIsLoading(true)
       const { data } = await supabase.from('teams').select(`
         *,
         members:profiles (
@@ -24,13 +28,21 @@ const TeamsWrapper = () => {
       if (data) {
         setTeams(data)
       }
+
+      setIsLoading(false)
     }
 
     getTeams()
   }, [supabase])
 
+  const TeamSkeletons = () =>
+    Array.from({ length: 5 }).map((_, index) => <TeamSkeleton key={index} />)
+
+  if (!userProfile) return <TeamSkeletons />
+
   return (
     <>
+      {isLoading && <TeamSkeletons />}
       {teams.map((team) => (
         <Team key={team.id} data={team} />
       ))}

--- a/src/components/Teams/TeamsWrapper.tsx
+++ b/src/components/Teams/TeamsWrapper.tsx
@@ -43,9 +43,18 @@ const TeamsWrapper = () => {
   return (
     <>
       {isLoading && <TeamSkeletons />}
-      {teams.map((team) => (
-        <Team key={team.id} data={team} />
-      ))}
+      {teams.length ? (
+        teams.map((team) => <Team key={team.id} data={team} />)
+      ) : (
+        <div className="flex h-1/2 w-full flex-col items-center justify-center">
+          <h3 className="mb-2 text-3xl font-semibold">
+            You have no teams yet
+          </h3>
+          <h4 className="text-xl text-slate-600 dark:text-zinc-400">
+            Create first team using the button above.
+          </h4>
+        </div>
+      )}
     </>
   )
 }

--- a/src/components/Teams/TeamsWrapper.tsx
+++ b/src/components/Teams/TeamsWrapper.tsx
@@ -1,0 +1,52 @@
+import { Team } from '@/components'
+import { UserProfile } from '@/types'
+
+const userProfiles: UserProfile[] = [
+  {
+    avatar_id: null,
+    bio: 'Team Leader',
+    created_at: '2021-08-18T18:00:00.000Z',
+    first_name: 'John',
+    id: '1',
+    last_name: 'Doe',
+    user_id: '1234',
+  },
+  {
+    avatar_id: null,
+    bio: 'Team Leader',
+    created_at: '2021-08-18T18:00:00.000Z',
+    first_name: 'John',
+    id: '1',
+    last_name: 'Doe',
+    user_id: '1234',
+  },
+  {
+    avatar_id: null,
+    bio: 'Team Leader',
+    created_at: '2021-08-18T18:00:00.000Z',
+    first_name: 'John',
+    id: '1',
+    last_name: 'Doe',
+    user_id: '1234',
+  },
+  {
+    avatar_id: null,
+    bio: 'Team Leader',
+    created_at: '2021-08-18T18:00:00.000Z',
+    first_name: 'John',
+    id: '1',
+    last_name: 'Doe',
+    user_id: '1234',
+  },
+]
+
+const TeamsWrapper = () => {
+  return (
+    <>
+      <Team members={userProfiles} name="California Team" />
+      <Team members={[]} name="Los Angeles Team" />
+    </>
+  )
+}
+
+export default TeamsWrapper

--- a/src/components/Teams/TeamsWrapper.tsx
+++ b/src/components/Teams/TeamsWrapper.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { Team, TeamSkeleton } from '@/components'
-import { useAuth } from '@/contexts'
+import { PageHeading, Team, TeamSkeleton } from '@/components'
+import { useAuth, useTeamsSearchContext } from '@/contexts'
 import { Database, TeamData } from '@/types'
 import { sortTeams } from '@/utils'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
@@ -12,6 +12,7 @@ const TeamsWrapper = () => {
   const supabase = createClientComponentClient<Database>()
   const [teams, setTeams] = useState<TeamData[]>([])
   const [isLoading, setIsLoading] = useState(false)
+  const { setTeams: setSearchSource, searchResult } = useTeamsSearchContext()
 
   useEffect(() => {
     const getTeams = async () => {
@@ -36,6 +37,10 @@ const TeamsWrapper = () => {
     getTeams()
   }, [supabase])
 
+  useEffect(() => {
+    setSearchSource(teams)
+  }, [teams, setSearchSource])
+
   const TeamSkeletons = () =>
     Array.from({ length: 5 }).map((_, index) => <TeamSkeleton key={index} />)
 
@@ -45,13 +50,26 @@ const TeamsWrapper = () => {
     <>
       {isLoading && <TeamSkeletons />}
       {teams.length ? (
-        sortTeams(teams).map((team) => <Team key={team.id} data={team} />)
+        searchResult.length ? (
+          sortTeams(searchResult).map((team) => (
+            <Team key={team.id} data={team} />
+          ))
+        ) : (
+          <div className="w-full py-8 text-center">
+            <PageHeading
+              title="No Team Found"
+              subtitle="There is no team or member with specified name."
+              noSpacer
+            />
+          </div>
+        )
       ) : (
-        <div className="flex h-1/2 w-full flex-col items-center justify-center">
-          <h3 className="mb-2 text-3xl font-semibold">You have no teams yet</h3>
-          <h4 className="text-xl text-slate-600 dark:text-zinc-400">
-            Create first team using the button above.
-          </h4>
+        <div className="w-full py-8 text-center">
+          <PageHeading
+            title="You Have No Teams Yet"
+            subtitle="Create first team using the button above."
+            noSpacer
+          />
         </div>
       )}
     </>

--- a/src/components/Teams/TeamsWrapper.tsx
+++ b/src/components/Teams/TeamsWrapper.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { PageHeading, Team, TeamSkeleton } from '@/components'
+import { PageHeading, Team, TeamsWrapperSkeleton } from '@/components'
 import { useAuth, useTeamsSearchContext } from '@/contexts'
 import { Database, TeamData } from '@/types'
 import { sortTeams } from '@/utils'
@@ -41,14 +41,11 @@ const TeamsWrapper = () => {
     setSearchSource(teams)
   }, [teams, setSearchSource])
 
-  const TeamSkeletons = () =>
-    Array.from({ length: 5 }).map((_, index) => <TeamSkeleton key={index} />)
-
-  if (!userProfile) return <TeamSkeletons />
+  if (!userProfile) return <TeamsWrapperSkeleton />
 
   return (
     <>
-      {isLoading && <TeamSkeletons />}
+      {isLoading && <TeamsWrapperSkeleton />}
       {teams.length ? (
         searchResult.length ? (
           sortTeams(searchResult).map((team) => (

--- a/src/components/Teams/TeamsWrapper.tsx
+++ b/src/components/Teams/TeamsWrapper.tsx
@@ -3,6 +3,7 @@
 import { Team, TeamSkeleton } from '@/components'
 import { useAuth } from '@/contexts'
 import { Database, TeamData } from '@/types'
+import { sortTeams } from '@/utils'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
 import { useEffect, useState } from 'react'
 
@@ -44,12 +45,10 @@ const TeamsWrapper = () => {
     <>
       {isLoading && <TeamSkeletons />}
       {teams.length ? (
-        teams.map((team) => <Team key={team.id} data={team} />)
+        sortTeams(teams).map((team) => <Team key={team.id} data={team} />)
       ) : (
         <div className="flex h-1/2 w-full flex-col items-center justify-center">
-          <h3 className="mb-2 text-3xl font-semibold">
-            You have no teams yet
-          </h3>
+          <h3 className="mb-2 text-3xl font-semibold">You have no teams yet</h3>
           <h4 className="text-xl text-slate-600 dark:text-zinc-400">
             Create first team using the button above.
           </h4>

--- a/src/components/Teams/TeamsWrapper.tsx
+++ b/src/components/Teams/TeamsWrapper.tsx
@@ -1,50 +1,39 @@
-import { Team } from '@/components'
-import { UserProfile } from '@/types'
+'use client'
 
-const userProfiles: UserProfile[] = [
-  {
-    avatar_id: null,
-    bio: 'Team Leader',
-    created_at: '2021-08-18T18:00:00.000Z',
-    first_name: 'John',
-    id: '1',
-    last_name: 'Doe',
-    user_id: '1234',
-  },
-  {
-    avatar_id: null,
-    bio: 'Team Leader',
-    created_at: '2021-08-18T18:00:00.000Z',
-    first_name: 'John',
-    id: '1',
-    last_name: 'Doe',
-    user_id: '1234',
-  },
-  {
-    avatar_id: null,
-    bio: 'Team Leader',
-    created_at: '2021-08-18T18:00:00.000Z',
-    first_name: 'John',
-    id: '1',
-    last_name: 'Doe',
-    user_id: '1234',
-  },
-  {
-    avatar_id: null,
-    bio: 'Team Leader',
-    created_at: '2021-08-18T18:00:00.000Z',
-    first_name: 'John',
-    id: '1',
-    last_name: 'Doe',
-    user_id: '1234',
-  },
-]
+import { Team } from '@/components'
+import { Database, TeamData } from '@/types'
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { useEffect, useState } from 'react'
 
 const TeamsWrapper = () => {
+  const supabase = createClientComponentClient<Database>()
+  const [teams, setTeams] = useState<TeamData[]>([])
+
+  useEffect(() => {
+    const getTeams = async () => {
+      const { data } = await supabase.from('teams').select(`
+        *,
+        members:profiles (
+          *,
+          role:roles (
+            *
+          )
+        )
+      `)
+
+      if (data) {
+        setTeams(data)
+      }
+    }
+
+    getTeams()
+  }, [supabase])
+
   return (
     <>
-      <Team members={userProfiles} name="California Team" />
-      <Team members={[]} name="Los Angeles Team" />
+      {teams.map((team) => (
+        <Team key={team.id} data={team} />
+      ))}
     </>
   )
 }

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -36,7 +36,7 @@ const Tooltip = ({ tooltipTargetRef, message }: Props) => {
   return (
     <span
       className={classNames(
-        'absolute left-1/2 top-full z-50 mt-1 w-max -translate-x-1/2 rounded-md bg-slate-800 px-3 py-2 transition-transform',
+        'absolute left-1/2 top-full z-50 mt-1 w-max -translate-x-1/2 rounded-md bg-slate-800 px-3 py-2 transition-transform dark:bg-zinc-200',
         {
           'scale-100': isTooltipVisible,
           'scale-0': !isTooltipVisible,
@@ -44,9 +44,12 @@ const Tooltip = ({ tooltipTargetRef, message }: Props) => {
       )}
     >
       <p
-        className={classNames('text-xs font-medium text-slate-50', {
-          'whitespace-pre-wrap text-center': isMessageArray,
-        })}
+        className={classNames(
+          'text-xs font-medium text-slate-100 dark:text-zinc-900',
+          {
+            'whitespace-pre-wrap text-center': isMessageArray,
+          },
+        )}
       >
         {isMessageArray ? message.join('\n') : message}
       </p>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -43,6 +43,8 @@ export { default as ShellSkeleton } from './Skeletons/ShellSkeleton'
 export { default as SidebarSkeleton } from './Skeletons/SidebarSkeleton'
 export { default as SignupSkeleton } from './Skeletons/SignupSkeleton'
 export { default as TeamSkeleton } from './Skeletons/TeamSkeleton'
+export { default as TeamsSkeleton } from './Skeletons/TeamsSkeleton'
+export { default as TeamsWrapperSkeleton } from './Skeletons/TeamsWrapperSkeleton'
 export { default as ThemeSkeleton } from './Skeletons/ThemeSkeleton'
 
 // COMMON

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -41,6 +41,7 @@ export { default as SettingsSkeleton } from './Skeletons/SettingsSkeleton'
 export { default as ShellSkeleton } from './Skeletons/ShellSkeleton'
 export { default as SidebarSkeleton } from './Skeletons/SidebarSkeleton'
 export { default as SignupSkeleton } from './Skeletons/SignupSkeleton'
+export { default as TeamSkeleton } from './Skeletons/TeamSkeleton'
 export { default as ThemeSkeleton } from './Skeletons/ThemeSkeleton'
 
 // COMMON

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,6 +18,7 @@ export { default as ThemeSettings } from './Settings/ThemeSettings'
 // TEAMS
 export { default as Team } from './Teams/Team'
 export { default as TeamFooter } from './Teams/TeamFooter'
+export { default as TeamsSearchInput } from './Teams/TeamsSearchInput'
 export { default as TeamsWrapper } from './Teams/TeamsWrapper'
 
 // SKELETONS

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,6 +17,7 @@ export { default as ThemeSettings } from './Settings/ThemeSettings'
 
 // TEAMS
 export { default as Team } from './Teams/Team'
+export { default as CreateTeamModal } from './Teams/CreateTeamModal'
 export { default as TeamFooter } from './Teams/TeamFooter'
 export { default as TeamsSearchInput } from './Teams/TeamsSearchInput'
 export { default as TeamsWrapper } from './Teams/TeamsWrapper'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -15,6 +15,10 @@ export { default as SettingsSidebar } from './Settings/SettingsSidebar'
 export { default as Theme } from './Settings/Theme'
 export { default as ThemeSettings } from './Settings/ThemeSettings'
 
+// TEAMS
+export { default as Team } from './Teams/Team'
+export { default as TeamFooter } from './Teams/TeamFooter'
+
 // SKELETONS
 export { default as AuthFormTitleSkeleton } from './Skeletons/AuthFormTitleSkeleton'
 export { default as AvatarSettingsSkeleton } from './Skeletons/AvatarSettingsSkeleton'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,6 +18,7 @@ export { default as ThemeSettings } from './Settings/ThemeSettings'
 // TEAMS
 export { default as Team } from './Teams/Team'
 export { default as TeamFooter } from './Teams/TeamFooter'
+export { default as TeamsWrapper } from './Teams/TeamsWrapper'
 
 // SKELETONS
 export { default as AuthFormTitleSkeleton } from './Skeletons/AuthFormTitleSkeleton'

--- a/src/contexts/TeamsSearchContext.tsx
+++ b/src/contexts/TeamsSearchContext.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { TeamData } from '@/types'
+import {
+  Dispatch,
+  PropsWithChildren,
+  SetStateAction,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from 'react'
+
+interface TeamsSearchContextValue {
+  teams: TeamData[]
+  setTeams: Dispatch<SetStateAction<TeamData[]>>
+  setQuery: Dispatch<SetStateAction<string>>
+  searchResult: TeamData[]
+}
+
+const Context = createContext<TeamsSearchContextValue>({
+  teams: [],
+  setTeams: () => {},
+  setQuery: () => {},
+  searchResult: [],
+})
+
+const TeamsSearchContext = ({ children }: PropsWithChildren) => {
+  const [teams, setTeams] = useState<TeamData[]>([])
+  const [query, setQuery] = useState('')
+  const [searchResult, setSearchResult] = useState<TeamData[]>([])
+
+  useEffect(() => {
+    const doesStartWithQuery = (string: string) =>
+      string.toLowerCase().startsWith(query.toLowerCase())
+
+    const sortedTeamsByTeamName = teams.filter((team) =>
+      doesStartWithQuery(team.name),
+    )
+    const sortedTeamsByMembersNames = teams.filter((team) =>
+      team.members.some(
+        (member) =>
+          doesStartWithQuery(member.first_name) ||
+          doesStartWithQuery(member.last_name) ||
+          doesStartWithQuery(`${member.first_name} ${member.last_name}`),
+      ),
+    )
+
+    // Delete duplicates using Set constructor
+    setSearchResult([
+      ...new Set(sortedTeamsByTeamName.concat(sortedTeamsByMembersNames)),
+    ])
+  }, [query, teams])
+
+  return (
+    <Context.Provider
+      value={{
+        teams,
+        setTeams,
+        setQuery,
+        searchResult,
+      }}
+    >
+      {children}
+    </Context.Provider>
+  )
+}
+
+export const useTeamsSearchContext = () => useContext(Context)
+
+export default TeamsSearchContext

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,1 +1,2 @@
 export { default as AuthContext, useAuth } from './AuthContext'
+export { default as TeamsSearchContext, useTeamsSearchContext } from './TeamsSearchContext'

--- a/src/types/ModalProps.ts
+++ b/src/types/ModalProps.ts
@@ -1,0 +1,6 @@
+import { Dispatch, SetStateAction } from 'react'
+
+export interface ModalProps {
+  isVisible: boolean
+  setIsVisible: Dispatch<SetStateAction<boolean>>
+}

--- a/src/types/TeamData.ts
+++ b/src/types/TeamData.ts
@@ -1,0 +1,6 @@
+import { Team } from '@/types'
+import { TeamMember } from '@/types'
+
+export interface TeamData extends Team {
+  members: TeamMember[]
+}

--- a/src/types/TeamMember.ts
+++ b/src/types/TeamMember.ts
@@ -1,0 +1,5 @@
+import { Role, UserProfile } from '@/types'
+
+export interface TeamMember extends UserProfile {
+  role: Role | null
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export type { AvatarSize } from './Avatar'
 export type { LoginErrors, SignupErrors, Error } from './Errors'
+export type { ModalProps } from './ModalProps'
 export type { Review } from './Review'
 export type { Database, UserProfile, Team, Role } from './supabase'
 export type { TeamData } from './TeamData'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,6 @@
 export type { AvatarSize } from './Avatar'
 export type { LoginErrors, SignupErrors, Error } from './Errors'
 export type { Review } from './Review'
-export type { Database, UserProfile } from './supabase'
+export type { Database, UserProfile, Team, Role } from './supabase'
+export type { TeamData } from './TeamData'
+export type { TeamMember } from './TeamMember'

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -10,6 +10,24 @@ export type Json =
 export interface Database {
   public: {
     Tables: {
+      organisations: {
+        Row: {
+          created_at: string
+          id: string
+          name: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          name: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          name?: string
+        }
+        Relationships: []
+      }
       profiles: {
         Row: {
           avatar_id: string | null
@@ -18,6 +36,7 @@ export interface Database {
           first_name: string
           id: string
           last_name: string
+          organisation_id: string
           role_id: string | null
           team_id: string | null
           type: string | null
@@ -30,6 +49,7 @@ export interface Database {
           first_name: string
           id?: string
           last_name: string
+          organisation_id: string
           role_id?: string | null
           team_id?: string | null
           type?: string | null
@@ -42,12 +62,20 @@ export interface Database {
           first_name?: string
           id?: string
           last_name?: string
+          organisation_id?: string
           role_id?: string | null
           team_id?: string | null
           type?: string | null
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: 'profiles_organisation_id_fkey'
+            columns: ['organisation_id']
+            isOneToOne: false
+            referencedRelation: 'organisations'
+            referencedColumns: ['id']
+          },
           {
             foreignKeyName: 'profiles_role_id_fkey'
             columns: ['role_id']
@@ -105,36 +133,58 @@ export interface Database {
           created_at: string
           id: string
           name: string
+          organisation_id: string
         }
         Insert: {
           created_at?: string
           id?: string
           name: string
+          organisation_id: string
         }
         Update: {
           created_at?: string
           id?: string
           name?: string
+          organisation_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: 'roles_organisation_id_fkey'
+            columns: ['organisation_id']
+            isOneToOne: false
+            referencedRelation: 'organisations'
+            referencedColumns: ['id']
+          },
+        ]
       }
       teams: {
         Row: {
           created_at: string
           id: string
           name: string
+          organisation_id: string
         }
         Insert: {
           created_at?: string
           id?: string
           name: string
+          organisation_id: string
         }
         Update: {
           created_at?: string
           id?: string
           name?: string
+          organisation_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: 'teams_organisation_id_fkey'
+            columns: ['organisation_id']
+            isOneToOne: false
+            referencedRelation: 'organisations'
+            referencedColumns: ['id']
+          },
+        ]
       }
     }
     Views: {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -18,6 +18,9 @@ export interface Database {
           first_name: string
           id: string
           last_name: string
+          role_id: string | null
+          team_id: string | null
+          type: string | null
           user_id: string
         }
         Insert: {
@@ -27,6 +30,9 @@ export interface Database {
           first_name: string
           id?: string
           last_name: string
+          role_id?: string | null
+          team_id?: string | null
+          type?: string | null
           user_id: string
         }
         Update: {
@@ -36,12 +42,30 @@ export interface Database {
           first_name?: string
           id?: string
           last_name?: string
+          role_id?: string | null
+          team_id?: string | null
+          type?: string | null
           user_id?: string
         }
         Relationships: [
           {
+            foreignKeyName: 'profiles_role_id_fkey'
+            columns: ['role_id']
+            isOneToOne: false
+            referencedRelation: 'roles'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'profiles_team_id_fkey'
+            columns: ['team_id']
+            isOneToOne: false
+            referencedRelation: 'teams'
+            referencedColumns: ['id']
+          },
+          {
             foreignKeyName: 'profiles_user_id_fkey'
             columns: ['user_id']
+            isOneToOne: false
             referencedRelation: 'users'
             referencedColumns: ['id']
           },
@@ -70,10 +94,47 @@ export interface Database {
           {
             foreignKeyName: 'reviews_profile_id_fkey'
             columns: ['profile_id']
+            isOneToOne: false
             referencedRelation: 'profiles'
             referencedColumns: ['id']
           },
         ]
+      }
+      roles: {
+        Row: {
+          created_at: string
+          id: string
+          name: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          name: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          name?: string
+        }
+        Relationships: []
+      }
+      teams: {
+        Row: {
+          created_at: string
+          id: string
+          name: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          name: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          name?: string
+        }
+        Relationships: []
       }
     }
     Views: {
@@ -87,6 +148,7 @@ export interface Database {
           {
             foreignKeyName: 'reviews_profile_id_fkey'
             columns: ['profile_id']
+            isOneToOne: false
             referencedRelation: 'profiles'
             referencedColumns: ['id']
           },
@@ -106,3 +168,5 @@ export interface Database {
 }
 
 export type UserProfile = Database['public']['Tables']['profiles']['Row']
+export type Team = Database['public']['Tables']['teams']['Row']
+export type Role = Database['public']['Tables']['roles']['Row']

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,3 @@
 export { isWithinOneMinute } from './isWithinOneMinute'
+export { sortObjectsArrayAlphabetically } from './sortObjectsArrayAlphabetically'
+export { sortTeams } from './sortTeams'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { isWithinOneMinute } from './isWithinOneMinute'
 export { sortObjectsArrayAlphabetically } from './sortObjectsArrayAlphabetically'
+export { sortTeamMembers } from './sortTeamMembers'
 export { sortTeams } from './sortTeams'

--- a/src/utils/sortObjectsArrayAlphabetically.ts
+++ b/src/utils/sortObjectsArrayAlphabetically.ts
@@ -1,0 +1,17 @@
+type EnsureStringProperty<T, K extends keyof T> = {
+  [P in keyof T]: P extends K ? string : T[P]
+}
+
+export function sortObjectsArrayAlphabetically<T, K extends keyof T>(
+  array: EnsureStringProperty<T, K>[],
+  property: K,
+) {
+  // Type assertions are safe here.
+  const sortedArray = array.sort((objectA, objectB) => {
+    return (objectA[property] as string).localeCompare(
+      objectB[property] as string,
+    )
+  })
+
+  return sortedArray
+}

--- a/src/utils/sortTeamMembers.ts
+++ b/src/utils/sortTeamMembers.ts
@@ -1,0 +1,29 @@
+import { TeamMember } from '@/types'
+import { sortObjectsArrayAlphabetically } from '@/utils'
+
+export function sortTeamMembers(members: TeamMember[]) {
+  const sortedMembers = members.sort((memberA, memberB) => {
+    const memberAIsTeamLeader = memberA.type === 'team_leader'
+    const memberBIsTeamLeader = memberB.type === 'team_leader'
+
+    return memberAIsTeamLeader && !memberBIsTeamLeader
+      ? -1
+      : memberBIsTeamLeader && !memberAIsTeamLeader
+      ? 1
+      : 0
+  })
+
+  const firstRegularTeamMemberIndex = sortedMembers.findIndex(
+    (member) => member.type !== 'team_leader',
+  )
+
+  const [teamLeaders, regularTeamMembers] = [
+    sortedMembers.slice(0, firstRegularTeamMemberIndex),
+    sortedMembers.slice(firstRegularTeamMemberIndex),
+  ]
+
+  return [
+    ...sortObjectsArrayAlphabetically(teamLeaders, 'first_name'),
+    ...sortObjectsArrayAlphabetically(regularTeamMembers, 'first_name'),
+  ]
+}

--- a/src/utils/sortTeams.ts
+++ b/src/utils/sortTeams.ts
@@ -1,0 +1,29 @@
+import { TeamData } from '@/types'
+import { sortObjectsArrayAlphabetically } from '@/utils'
+
+export function sortTeams(teams: TeamData[]) {
+  const sortedTeamsByMembers = teams.sort((teamA, teamB) => {
+    const teamAHasMembers = !!teamA.members.length
+    const teamBHasMembers = !!teamB.members.length
+
+    return teamAHasMembers && !teamBHasMembers
+      ? -1
+      : teamBHasMembers && !teamAHasMembers
+      ? 1
+      : 0
+  })
+
+  const firstTeamWithNoMembersIndex = sortedTeamsByMembers.findIndex(
+    (team) => !team.members.length,
+  )
+
+  const [teamsWithMembers, teamsWithNoMembers] = [
+    sortedTeamsByMembers.slice(0, firstTeamWithNoMembersIndex),
+    sortedTeamsByMembers.slice(firstTeamWithNoMembersIndex),
+  ]
+
+  return [
+    ...sortObjectsArrayAlphabetically(teamsWithMembers, 'name'),
+    ...sortObjectsArrayAlphabetically(teamsWithNoMembers, 'name'),
+  ]
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,7 +13,10 @@ module.exports = {
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic':
-          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+        'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+      },
+      boxShadow: {
+        'main': '0px 0px 8px 0px rgba(0, 0, 0, 0.08)'
       },
       colors: {
         primary: colors.green,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
### Resolves issue #66

## Changes Made
- Created UI accordingly to the design specifications.
- Data is connected with database, handling when no data is present is covered. 
- Team leaders have crown icon.
- Team name click redirects to team page.
- `Assigned tasks` and `projects` are static.
- Dark mode supported.
- Implemented filtering by team or member name.
- When user hovers a member, tooltip with name is visible.

<img width="1757" alt="Teams-page" src="https://github.com/MoDrazzz/teamguru/assets/44100186/91de35b0-431f-4799-afc6-00b9bdcce166">
<img width="1509" alt="Teams-filtering" src="https://github.com/MoDrazzz/teamguru/assets/44100186/6e37a943-59ca-47f6-a5a5-71b571fcdf38">
<img width="226" alt="Teams-tooltip" src="https://github.com/MoDrazzz/teamguru/assets/44100186/c3bbadc4-c701-4a7d-b18e-3c7227983aaf">